### PR TITLE
Calling Taghelpers inside Block Helpers is not possible

### DIFF
--- a/lib/handlebars_engine.js
+++ b/lib/handlebars_engine.js
@@ -21,34 +21,35 @@ util.inherits(HandlebarsEngine, BaseEngine);
 HandlebarsEngine.extension = ".handlebars";
 
 HandlebarsEngine.renderFunction = function(template, content, partials, helpers) {
+    _.each(helpers.tag, function(helper_function, name) {
+        Handlebars.registerHelper(name, helper_function);
+    });
 
-	var content_with_helpers = _.extend({}, content, helpers.tag);
+    // register helpers
+    _.each(helpers.block, function(helper_function, name) {
+        Handlebars.registerHelper(name, function() {
+            try {
+                return helper_function.apply(this, Array.prototype.slice.call(arguments, 0));
+            } catch (e) {
+                var last_arg = arguments[arguments.length -1];
+                // check if the last argument is a options hash containing the propery fn.
+                if (last_arg.fn) {
+                    return helper_function(last_arg.fn(this));
+                } else {
+                    // if not just call the helper with the first argument
+                    return helper_function(arguments[0]);
+                }
+            }
+        });
+    });
 
-	// register helpers
-	_.each(helpers.block, function(helper_function, name) {
-		Handlebars.registerHelper(name, function() {
-			try {
-				return helper_function.apply(this, Array.prototype.slice.call(arguments, 0));
-			} catch (e) {
-				var last_arg = arguments[arguments.length -1];
-				// check if the last argument is a options hash containing the propery fn.
-				if (last_arg.fn) {
-					return helper_function(last_arg.fn(this));
-				} else {
-					// if not just call the helper with the first argument
-					return helper_function(arguments[0]);
-				}
-			}
-		});
-	});
+    // register partials
+    _.each(partials, function(partial, name) {
+        Handlebars.registerPartial(name, partial);
+    });
 
-	// register partials
-	_.each(partials, function(partial, name) {
-		Handlebars.registerPartial(name, partial);
-	});
-
-	var compiled_template = Handlebars.compile(template);
-	return compiled_template(content_with_helpers);
-}
+    var compiled_template = Handlebars.compile(template);
+    return compiled_template(content);
+};
 
 module.exports = HandlebarsEngine;


### PR DESCRIPTION
Taghelpers are not registered with Handlebars but injected through content object. This way if they are called inside of a block helper (which in turn uses options.fn() to render the inner template) handlebars doesn't see them.

This patch attempts to fix that.
